### PR TITLE
✨ Add Send Label Email API with PDF Attachments

### DIFF
--- a/src/components/emails/label-email.tsx
+++ b/src/components/emails/label-email.tsx
@@ -1,0 +1,226 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import * as React from 'react'
+
+interface LabelEmailProps {
+  customerName: string
+  orderNumber: string
+  orderDate: string
+  packageName: string
+  shoeType: string
+  quantity: number
+  specialInstructions?: string
+}
+
+export const LabelEmail = ({
+  customerName,
+  orderNumber,
+  orderDate,
+  packageName,
+  shoeType,
+  quantity,
+  specialInstructions,
+}: LabelEmailProps) => (
+  <Html>
+    <Head />
+    <Preview>Your shipping label is ready - {orderNumber}</Preview>
+    <Body style={main}>
+      <Container style={container}>
+        <Section style={header}>
+          <Img
+            src="https://offseasonshoes.com/logo.png"
+            width="150"
+            height="auto"
+            alt="OFFseason"
+            style={logo}
+          />
+        </Section>
+
+        <Section style={content}>
+          <Heading style={h1}>Your Shipping Label is Ready!</Heading>
+          
+          <Text style={text}>
+            Hi {customerName},
+          </Text>
+          
+          <Text style={text}>
+            Great news! Your prepaid shipping label for order <strong>{orderNumber}</strong> is attached to this email.
+          </Text>
+
+          <Section style={orderDetails}>
+            <Heading style={h2}>Order Details</Heading>
+            <Text style={detailText}>
+              <strong>Order Number:</strong> {orderNumber}
+            </Text>
+            <Text style={detailText}>
+              <strong>Order Date:</strong> {orderDate}
+            </Text>
+            <Text style={detailText}>
+              <strong>Service:</strong> {packageName}
+            </Text>
+            <Text style={detailText}>
+              <strong>Shoe Type:</strong> {shoeType}
+            </Text>
+            <Text style={detailText}>
+              <strong>Quantity:</strong> {quantity} pair{quantity > 1 ? 's' : ''}
+            </Text>
+            {specialInstructions && (
+              <Text style={detailText}>
+                <strong>Special Instructions:</strong> {specialInstructions}
+              </Text>
+            )}
+          </Section>
+
+          <Section style={instructions}>
+            <Heading style={h2}>Shipping Instructions</Heading>
+            <Text style={text}>
+              1. <strong>Print the attached label</strong> and securely attach it to your package
+            </Text>
+            <Text style={text}>
+              2. <strong>Package your shoes</strong> in a sturdy box with adequate protection
+            </Text>
+            <Text style={text}>
+              3. <strong>Drop off at any Royal Mail location</strong> or schedule a collection
+            </Text>
+            <Text style={text}>
+              4. <strong>Keep your receipt</strong> for tracking purposes
+            </Text>
+          </Section>
+
+          <Section style={trackingSection}>
+            <Text style={text}>
+              Once we receive your shoes, we'll send you a confirmation email and begin the cleaning process immediately.
+            </Text>
+          </Section>
+
+          <Hr style={hr} />
+          
+          <Section style={footer}>
+            <Text style={footerText}>
+              Questions? Reply to this email or contact us at{' '}
+              <a href="mailto:info@offseasonshoes.com" style={link}>
+                info@offseasonshoes.com
+              </a>
+            </Text>
+            <Text style={footerText}>
+              Thank you for choosing OFFseason for your shoe cleaning needs!
+            </Text>
+          </Section>
+        </Section>
+      </Container>
+    </Body>
+  </Html>
+)
+
+export default LabelEmail
+
+// Styles
+const main = {
+  backgroundColor: '#ffffff',
+  fontFamily: '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+}
+
+const container = {
+  margin: '0 auto',
+  padding: '20px 0 48px',
+  maxWidth: '600px',
+}
+
+const header = {
+  padding: '20px 0',
+  textAlign: 'center' as const,
+}
+
+const logo = {
+  margin: '0 auto',
+}
+
+const content = {
+  padding: '20px',
+}
+
+const h1 = {
+  color: '#1a1a1a',
+  fontSize: '28px',
+  fontWeight: 'bold',
+  textAlign: 'center' as const,
+  margin: '20px 0',
+}
+
+const h2 = {
+  color: '#1a1a1a',
+  fontSize: '20px',
+  fontWeight: 'bold',
+  margin: '20px 0 10px',
+}
+
+const text = {
+  color: '#444',
+  fontSize: '16px',
+  lineHeight: '24px',
+  margin: '16px 0',
+}
+
+const detailText = {
+  color: '#444',
+  fontSize: '14px',
+  lineHeight: '20px',
+  margin: '8px 0',
+}
+
+const orderDetails = {
+  backgroundColor: '#f8f9fa',
+  border: '1px solid #e9ecef',
+  borderRadius: '8px',
+  padding: '20px',
+  margin: '20px 0',
+}
+
+const instructions = {
+  backgroundColor: '#fff3cd',
+  border: '1px solid #ffeaa7',
+  borderRadius: '8px',
+  padding: '20px',
+  margin: '20px 0',
+}
+
+const trackingSection = {
+  backgroundColor: '#d4edda',
+  border: '1px solid #c3e6cb',
+  borderRadius: '8px',
+  padding: '20px',
+  margin: '20px 0',
+}
+
+const hr = {
+  borderColor: '#e9ecef',
+  margin: '20px 0',
+}
+
+const footer = {
+  textAlign: 'center' as const,
+  margin: '20px 0',
+}
+
+const footerText = {
+  color: '#6c757d',
+  fontSize: '14px',
+  lineHeight: '20px',
+  margin: '8px 0',
+}
+
+const link = {
+  color: '#007bff',
+  textDecoration: 'underline',
+}

--- a/src/routes/send-label.ts
+++ b/src/routes/send-label.ts
@@ -1,0 +1,137 @@
+import { Hono } from 'hono'
+import { zValidator } from '@hono/zod-validator'
+import { z } from 'zod'
+import { getOrderData, updateOrderStatus } from '@/services/database'
+import { sendEmail, sendBusinessNotification, emailDelay } from '@/services/email'
+import LabelEmail from '@/components/emails/label-email'
+import type { ApiResponse } from '@/types'
+
+const app = new Hono()
+
+// Validation schema
+const sendLabelSchema = z.object({
+  orderReference: z.string().min(1, 'Order reference is required'),
+})
+
+/**
+ * POST /send-label
+ * Send shipping label email with PDF attachment
+ */
+app.post('/', async (c) => {
+  try {
+    // Parse form data
+    const body = await c.req.formData()
+    const orderReference = body.get('orderReference') as string
+    const labelFile = body.get('label') as File
+
+    // Validate required fields
+    if (!orderReference) {
+      return c.json<ApiResponse>({
+        success: false,
+        message: 'Order reference is required',
+        error: 'Missing orderReference in form data'
+      }, 400)
+    }
+
+    if (!labelFile) {
+      return c.json<ApiResponse>({
+        success: false,
+        message: 'Label PDF file is required',
+        error: 'Missing label file in form data'
+      }, 400)
+    }
+
+    // Validate file type
+    if (labelFile.type !== 'application/pdf') {
+      return c.json<ApiResponse>({
+        success: false,
+        message: 'Label must be a PDF file',
+        error: `Invalid file type: ${labelFile.type}`
+      }, 400)
+    }
+
+    console.log(`Processing send-label request for order: ${orderReference}`)
+
+    // Get order data
+    const orderData = await getOrderData(orderReference)
+    
+    // Convert file to buffer for attachment
+    const labelBuffer = Buffer.from(await labelFile.arrayBuffer())
+    
+    // Format order date
+    const orderDate = new Date(orderData.order.created_at).toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+
+    // Prepare email data
+    const emailProps = {
+      customerName: `${orderData.customer.first_name} ${orderData.customer.last_name}`,
+      orderNumber: orderData.order.order_reference,
+      orderDate,
+      packageName: orderData.package.name,
+      shoeType: orderData.order.shoe_type,
+      quantity: orderData.order.quantity,
+      specialInstructions: orderData.order.special_instructions,
+    }
+
+    // Send customer email with label attachment
+    const customerEmailResult = await sendEmail({
+      to: orderData.customer.email,
+      subject: `Your Shipping Label is Ready - Order #${orderReference}`,
+      react: LabelEmail(emailProps),
+      attachments: [
+        {
+          filename: `shipping-label-${orderReference}.pdf`,
+          content: labelBuffer,
+          contentType: 'application/pdf',
+        }
+      ]
+    })
+
+    if (!customerEmailResult.success) {
+      throw new Error(`Failed to send customer email: ${customerEmailResult.error}`)
+    }
+
+    // Wait before sending business notification
+    await emailDelay(2000)
+
+    // Send business notification (without attachment)
+    const businessEmailResult = await sendBusinessNotification(
+      `Shipping Label Sent - Order #${orderReference}`,
+      LabelEmail({
+        ...emailProps,
+        customerName: `${emailProps.customerName} (${orderData.customer.email})`,
+      })
+    )
+
+    // Update order status to indicate label has been sent
+    await updateOrderStatus(orderReference, 'label_sent')
+
+    console.log(`Label email sent successfully for order: ${orderReference}`)
+
+    return c.json<ApiResponse>({
+      success: true,
+      message: 'Shipping label email sent successfully',
+      data: {
+        orderReference,
+        customerEmail: orderData.customer.email,
+        customerEmailSent: customerEmailResult.success,
+        businessEmailSent: businessEmailResult.success,
+        messageId: customerEmailResult.messageId,
+      }
+    })
+
+  } catch (error) {
+    console.error('Send label error:', error)
+    
+    return c.json<ApiResponse>({
+      success: false,
+      message: 'Failed to send shipping label email',
+      error: error instanceof Error ? error.message : 'Unknown error'
+    }, 500)
+  }
+})
+
+export default app


### PR DESCRIPTION
## 📧 Send Label Email API

This PR adds the send-label email functionality for shoe cleaning orders.

### ✨ Features Added

- **`POST /send-label`** endpoint that accepts PDF attachments
- **React Email Template** with OFFseason branding
- **PDF Attachment Support** for shipping labels
- **Form Data Validation** for file uploads
- **Business Notifications** to internal team
- **Order Status Updates** to track label sending

### 📋 API Usage

```bash
curl -X POST http://localhost:3001/send-label \
  -F "orderReference=OS-CLEAN-1234567890" \
  -F "label=@shipping-label.pdf"
```

### 🎨 Email Template Features

- Professional OFFseason branding
- Order details display
- Step-by-step shipping instructions
- Responsive design
- Clear call-to-action

### 🔧 Technical Details

- **File Validation**: Only accepts PDF files
- **Buffer Handling**: Converts File to Buffer for Resend
- **Error Handling**: Comprehensive validation and error responses
- **Database Integration**: Updates order status and fetches customer data
- **Rate Limiting**: Delays between customer and business emails

### 🧪 Testing

The endpoint can be tested with:
1. Valid order reference from database
2. PDF file attachment
3. Proper form-data content-type

Ready for review and merge! 🚀